### PR TITLE
Remove the error causing #include "../fs/mount.h" statement

### DIFF
--- a/fs/aufs/vfsub.c
+++ b/fs/aufs/vfsub.c
@@ -23,7 +23,6 @@
 #include <linux/nsproxy.h>
 #include <linux/security.h>
 #include <linux/splice.h>
-#include "../fs/mount.h"
 #include "aufs.h"
 
 #ifdef CONFIG_AUFS_BR_FUSE


### PR DESCRIPTION
The include seems not to be necessary and causes problems when
compiling the module not in kernel source tree.
