### PR TITLE
Fixes for Linux 4.9

### DIFF
--- a/fs/aufs/i_op.c
+++ b/fs/aufs/i_op.c
@@ -1387,10 +1387,7 @@ struct inode_operations aufs_iop_nogetattr[AuIop_Last],
 		.getattr	= aufs_getattr,
 
 #ifdef CONFIG_AUFS_XATTR
-		.setxattr	= aufs_setxattr,
-		.getxattr	= aufs_getxattr,
 		.listxattr	= aufs_listxattr,
-		.removexattr	= aufs_removexattr,
 #endif
 
 		.readlink	= generic_readlink,
@@ -1419,10 +1416,7 @@ struct inode_operations aufs_iop_nogetattr[AuIop_Last],
 		.getattr	= aufs_getattr,
 
 #ifdef CONFIG_AUFS_XATTR
-		.setxattr	= aufs_setxattr,
-		.getxattr	= aufs_getxattr,
 		.listxattr	= aufs_listxattr,
-		.removexattr	= aufs_removexattr,
 #endif
 
 		.update_time	= aufs_update_time,
@@ -1440,10 +1434,7 @@ struct inode_operations aufs_iop_nogetattr[AuIop_Last],
 		.getattr	= aufs_getattr,
 
 #ifdef CONFIG_AUFS_XATTR
-		.setxattr	= aufs_setxattr,
-		.getxattr	= aufs_getxattr,
 		.listxattr	= aufs_listxattr,
-		.removexattr	= aufs_removexattr,
 #endif
 
 		.update_time	= aufs_update_time

--- a/fs/aufs/i_op_ren.c
+++ b/fs/aufs/i_op_ren.c
@@ -802,7 +802,8 @@ static void au_ren_rev_dt(int err, struct au_ren_args *a)
 /* ---------------------------------------------------------------------- */
 
 int aufs_rename(struct inode *_src_dir, struct dentry *_src_dentry,
-		struct inode *_dst_dir, struct dentry *_dst_dentry)
+		struct inode *_dst_dir, struct dentry *_dst_dentry,
+		unsigned int rename_flags)
 {
 	int err, flags;
 	/* reduce stack space */
@@ -811,6 +812,10 @@ int aufs_rename(struct inode *_src_dir, struct dentry *_src_dentry,
 	AuDbg("%pd, %pd\n", _src_dentry, _dst_dentry);
 	IMustLock(_src_dir);
 	IMustLock(_dst_dir);
+
+	err = -EINVAL;
+	if (rename_flags)
+		goto out;
 
 	err = -ENOMEM;
 	BUILD_BUG_ON(sizeof(*a) > PAGE_SIZE);

--- a/fs/aufs/inode.h
+++ b/fs/aufs/inode.h
@@ -311,17 +311,11 @@ AuStubVoid(au_plink_half_refresh, struct super_block *sb, aufs_bindex_t br_id);
 int au_cpup_xattr(struct dentry *h_dst, struct dentry *h_src, int ignore_flags,
 		  unsigned int verbose);
 ssize_t aufs_listxattr(struct dentry *dentry, char *list, size_t size);
-ssize_t aufs_getxattr(struct dentry *dentry, struct inode *inode,
-		      const char *name, void *value, size_t size);
-int aufs_setxattr(struct dentry *dentry, struct inode *inode, const char *name,
-		  const void *value, size_t size, int flags);
-int aufs_removexattr(struct dentry *dentry, const char *name);
-
-/* void au_xattr_init(struct super_block *sb); */
+void au_xattr_init(struct super_block *sb);
 #else
 AuStubInt0(au_cpup_xattr, struct dentry *h_dst, struct dentry *h_src,
 	   int ignore_flags, unsigned int verbose);
-/* AuStubVoid(au_xattr_init, struct super_block *sb); */
+AuStubVoid(au_xattr_init, struct super_block *sb);
 #endif
 
 #ifdef CONFIG_FS_POSIX_ACL

--- a/fs/aufs/inode.h
+++ b/fs/aufs/inode.h
@@ -238,7 +238,8 @@ int aufs_rmdir(struct inode *dir, struct dentry *dentry);
 /* i_op_ren.c */
 int au_wbr(struct dentry *dentry, aufs_bindex_t btgt);
 int aufs_rename(struct inode *src_dir, struct dentry *src_dentry,
-		struct inode *dir, struct dentry *dentry);
+		struct inode *dir, struct dentry *dentry,
+		unsigned int rename_flags);
 
 /* iinfo.c */
 struct inode *au_h_iptr(struct inode *inode, aufs_bindex_t bindex);

--- a/fs/aufs/super.c
+++ b/fs/aufs/super.c
@@ -923,7 +923,7 @@ static int aufs_fill_super(struct super_block *sb, void *raw_data,
 	sb->s_maxbytes = 0;
 	sb->s_stack_depth = 1;
 	au_export_init(sb);
-	/* au_xattr_init(sb); */
+	au_xattr_init(sb);
 
 	err = alloc_root(sb);
 	if (unlikely(err)) {


### PR DESCRIPTION
Two fixes for FTBFS issues with Linux 4.9.

The first problem is that the {get,set,remove}xattr inode operations have been remove, and filesystems must now use xattr handlers. There's already a partial implementation to use xattr handlers commented out in the source, so that implementation is completed and used instead of the unsupported callbacks.

The second issue is that the rename inode operation was replaced by the rename2 op, so aufs_rename needs an extra "flags" argument. Since aufs doesn't support the operations specified by the flags yet, it should return an error if the flags are non-zero.