### PR TITLE
fix compile bug:  no member named 'owner'

### DIFF
--- a/fs/aufs/i_op.c
+++ b/fs/aufs/i_op.c
@@ -589,7 +589,7 @@ out:
 
 void au_pin_hdir_set_owner(struct au_pin *p, struct task_struct *task)
 {
-#if defined(CONFIG_DEBUG_MUTEXES) || defined(CONFIG_SMP)
+#if defined(CONFIG_DEBUG_MUTEXES) || defined(CONFIG_MUTEX_SPIN_ON_OWNER)
 	p->hdir->hi_inode->i_mutex.owner = task;
 #endif
 }


### PR DESCRIPTION
In v4.4 kernel, compile error:
```
fs/aufs/i_op.c: In function 'au_pin_hdir_set_owner':
fs/aufs/i_op.c:593:28: error: 'struct mutex' has no member named 'owner'
  p->hdir->hi_inode->i_mutex.owner = task;
```

I found commit 7608a43d8f2e02f8b532f8e11481d7ecf8b5d3f9 in linux git
tree in v3.18 changes, option `CONFIG_SMP` has been replaced by
`CONFIG_MUTEX_SPIN_ON_OWNER`.