### PR TITLE
Fix oops due to overrun buf and fix uninitialized variable do_refresh

### DIFF
--- a/fs/aufs/opts.c
+++ b/fs/aufs/opts.c
@@ -1505,6 +1505,7 @@ static int au_opt_br(struct super_block *sb, struct au_opt *opt,
 {
 	int err, do_refresh;
 
+	do_refresh = 0;
 	err = 0;
 	switch (opt->type) {
 	case Opt_append:

--- a/fs/aufs/procfs.c
+++ b/fs/aufs/procfs.c
@@ -98,7 +98,7 @@ static ssize_t au_procfs_plm_write(struct file *file, const char __user *ubuf,
 		goto out;
 
 	err = -EINVAL;
-	if (unlikely(count > sizeof(buf)))
+	if (unlikely(count >= sizeof(buf)))
 		goto out;
 
 	err = copy_from_user(buf, ubuf, count);


### PR DESCRIPTION
when count equals sizeof(buf), buf[count] will cause overrun buf.


The variable do_refresh is not initialized and hence the
"do_refresh |= need_sigen_inc()" may always be true. fix
this by initializing do_refresh to zero.
